### PR TITLE
Remove swiftlint from CI builds

### DIFF
--- a/brd-ios/breadwallet.xcodeproj/project.pbxproj
+++ b/brd-ios/breadwallet.xcodeproj/project.pbxproj
@@ -3600,7 +3600,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "# Confirm homebrew root for M1 machines\nif test -d \"/opt/homebrew/bin/\"; then\n PATH=\"/opt/homebrew/bin/:${PATH}\"\nfi\nexport PATH\n\nif which swiftlint >/dev/null; then\n git status --porcelain | grep -v '^ \\?D' | cut -c 4- | sed 's/.* -> //' | tr -d '\"' | while read file \n do\n     if [[ \"$file\" == *.swift ]]; then\n         swiftlint \"$file\" --fix \n        swiftlint --config ../.swiftlint.yml \"$file\" --fix\n     fi\n done\nelse\n  if [ \"${CONFIGURATION}\" == \"Release\" ]; then\n    exit 0;\n  else\n    echo \"error: SwiftLint not installed, download from https://github.com/realm/SwiftLint or install via homebrew\"\n    exit 0\n  fi\nfi\n";
+			shellScript = "if which swiftlint >/dev/null; then\n git status --porcelain | grep -v '^ \\?D' | cut -c 4- | sed 's/.* -> //' | tr -d '\"' | while read file \n do\n     if [[ \"$file\" == *.swift ]]; then\n         swiftlint \"$file\" --fix \n        swiftlint --config ../.swiftlint.yml \"$file\" --fix\n     fi\n done\nelse\n exit 0\nfi\n";
 		};
 		7CDC6A5521125C14004AE68E /* Thin Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/brd-ios/ci_scripts/ci_post_clone.sh
+++ b/brd-ios/ci_scripts/ci_post_clone.sh
@@ -9,11 +9,7 @@
 # a nonzero exit code.
 set -e
 
-# Install SwiftLint to run lint checks
- brew install SwiftLint
-
 # Create the .env file
-
 BRD_ENV=../.env
 touch $BRD_ENV
 


### PR DESCRIPTION
Changes the project to use swiftlint only if present, which it will be on desktops, but not on CI

Also implies that the brew home needs to be manually added to the path on Apple Silicon devices