### PR TITLE
Clpeterson/fix/eth fee estimate

### DIFF
--- a/brd-ios/breadwallet.xcodeproj/project.pbxproj
+++ b/brd-ios/breadwallet.xcodeproj/project.pbxproj
@@ -5391,7 +5391,7 @@
 			repositoryURL = "https://github.com/rockwalletcode/WalletKitSwift.git";
 			requirement = {
 				kind = exactVersion;
-				version = 5.0.5;
+				version = 5.0.6;
 			};
 		};
 		7E5CB32B2834E63400EC787E /* XCRemoteSwiftPackageReference "cosmos" */ = {

--- a/brd-ios/breadwallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/brd-ios/breadwallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rockwalletcode/WalletKitCore.git",
       "state" : {
-        "revision" : "243f4a903258316363d958ddae50bfc5a41f6f57",
-        "version" : "5.0.4"
+        "revision" : "f8076654e33d33faa6ef723bce0c99e26d3ba358",
+        "version" : "5.0.6"
       }
     },
     {
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rockwalletcode/WalletKitSwift.git",
       "state" : {
-        "revision" : "7a8b2649deea725e7fa16e1348591212120e3afc",
-        "version" : "5.0.5"
+        "revision" : "ebe17412ac1e1f2cf18e5a1f32f7ff24bc1d7c6a",
+        "version" : "5.0.6"
       }
     }
   ],

--- a/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
+++ b/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
@@ -283,14 +283,12 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
             if max.currency.network.name == Currencies.shared.eth?.name {
                 let adjustTokenVal = max.tokenValue * 0.05
                 let adjustAmount = Amount(tokenString: "\(adjustTokenVal)", currency: max.currency)
-                print("max before: \(max.description)")
                 max = max - adjustAmount
-                print("max after: \(max.description)")
             }
             
-//            self?.amountView.forceUpdateAmount(amount: max)
+            self?.amountView.forceUpdateAmount(amount: max)
             
-            self?.updateFeesMax(amount: max)
+            self?.updateFeesMax()
         }
     }
     
@@ -316,8 +314,8 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
         }
     }
     
-    private func updateFeesMax(amount: Amount) {
-//        guard let amount = amount else { return }
+    @objc private func updateFeesMax() {
+        guard let amount = amount else { return }
         guard let address = address, !address.isEmpty else { return _ = handleValidationResult(.invalidAddress) }
         
         print("updateFeesMax Amount: \(amount.description)")

--- a/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
+++ b/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
@@ -114,7 +114,8 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
         guard timer?.isValid != true else { return }
         
         // start the timer
-        timer = Timer.scheduledTimer(timeInterval: 15,
+//        timer = Timer.scheduledTimer(timeInterval: 15,
+        timer = Timer.scheduledTimer(timeInterval: 120,
                                      target: self,
                                      selector: #selector(updateFees),
                                      userInfo: nil,
@@ -284,11 +285,11 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
                 let adjustTokenVal = max.tokenValue * 0.05
                 let adjustAmount = Amount(tokenString: "\(adjustTokenVal)", currency: max.currency)
                 max = max - adjustAmount
+                self?.amountView.forceUpdateAmount(amount: max)
+            } else {
+                self?.amountView.forceUpdateAmount(amount: max)
+                self?.updateFeesMax()
             }
-            
-            self?.amountView.forceUpdateAmount(amount: max)
-            
-            self?.updateFeesMax()
         }
     }
     
@@ -296,22 +297,12 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
         guard let amount = amount else { return }
         guard let address = address, !address.isEmpty else { return _ = handleValidationResult(.invalidAddress) }
         
-//        print("updateFees Amount: \(amount.description)")
-        
         sender.estimateFee(address: address, amount: amount, tier: feeLevel, isStake: false) { [weak self] result in
             DispatchQueue.main.async {
                 switch result {
                 case .success(let fee):
                     self?.currentFeeBasis = fee
                     self?.sendButton.isEnabled = true
-                    
-//                    guard let feeBasis = self?.currentFeeBasis,
-//                          let feeCurrency = self?.sender.wallet.feeCurrency else {
-//                        return
-//                    }
-//                    let fee = Amount(cryptoAmount: feeBasis.fee, currency: feeCurrency)
-//                    
-//                    print("updateFees fee: \(fee.description)")
                     
                 case .failure(let error):
                     self?.handleEstimateFeeError(error: error)
@@ -326,7 +317,7 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
         guard let amount = amount else { return }
         guard let address = address, !address.isEmpty else { return _ = handleValidationResult(.invalidAddress) }
         
-//        print("updateFeesMax Amount: \(amount.description)")
+        print("updateFeesMax Amount: \(amount.description)")
         
         sender.estimateFee(address: address, amount: amount, tier: feeLevel, isStake: false) { [weak self] result in
             DispatchQueue.main.async {
@@ -344,11 +335,13 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
                     print("updateFeesMax fee: \(fee.description)")
                     
                     var value = amount
-                    if amount.currency == fee.currency && amount.currency.network.name != Currencies.shared.eth?.name {
+                    if amount.currency == fee.currency {
                         value = amount > fee ? amount - fee : amount
                     }
 
-                    self?.amountView.forceUpdateAmount(amount: value)
+                    if value != amount {
+                        self?.amountView.forceUpdateAmount(amount: value)
+                    }
                     
                 case .failure(let error):
                     self?.handleEstimateFeeError(error: error)

--- a/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
+++ b/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
@@ -114,8 +114,7 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
         guard timer?.isValid != true else { return }
         
         // start the timer
-//        timer = Timer.scheduledTimer(timeInterval: 15,
-        timer = Timer.scheduledTimer(timeInterval: 120,
+        timer = Timer.scheduledTimer(timeInterval: 15,
                                      target: self,
                                      selector: #selector(updateFees),
                                      userInfo: nil,
@@ -282,7 +281,7 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
             self?.isSendingMax = true
             
             if max.currency.network.name == Currencies.shared.eth?.name {
-                let adjustTokenVal = max.tokenValue * 0.05
+                let adjustTokenVal = max.tokenValue * 0.15
                 let adjustAmount = Amount(tokenString: "\(adjustTokenVal)", currency: max.currency)
                 max = max - adjustAmount
                 self?.amountView.forceUpdateAmount(amount: max)
@@ -317,8 +316,6 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
         guard let amount = amount else { return }
         guard let address = address, !address.isEmpty else { return _ = handleValidationResult(.invalidAddress) }
         
-        print("updateFeesMax Amount: \(amount.description)")
-        
         sender.estimateFee(address: address, amount: amount, tier: feeLevel, isStake: false) { [weak self] result in
             DispatchQueue.main.async {
                 switch result {
@@ -331,8 +328,6 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
                         return
                     }
                     let fee = Amount(cryptoAmount: feeBasis.fee, currency: feeCurrency)
-                    
-                    print("updateFeesMax fee: \(fee.description)")
                     
                     var value = amount
                     if amount.currency == fee.currency {

--- a/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
+++ b/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
@@ -296,7 +296,7 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
         guard let amount = amount else { return }
         guard let address = address, !address.isEmpty else { return _ = handleValidationResult(.invalidAddress) }
         
-        print("updateFees Amount: \(amount.description)")
+//        print("updateFees Amount: \(amount.description)")
         
         sender.estimateFee(address: address, amount: amount, tier: feeLevel, isStake: false) { [weak self] result in
             DispatchQueue.main.async {
@@ -304,6 +304,14 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
                 case .success(let fee):
                     self?.currentFeeBasis = fee
                     self?.sendButton.isEnabled = true
+                    
+//                    guard let feeBasis = self?.currentFeeBasis,
+//                          let feeCurrency = self?.sender.wallet.feeCurrency else {
+//                        return
+//                    }
+//                    let fee = Amount(cryptoAmount: feeBasis.fee, currency: feeCurrency)
+//                    
+//                    print("updateFees fee: \(fee.description)")
                     
                 case .failure(let error):
                     self?.handleEstimateFeeError(error: error)
@@ -318,7 +326,7 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
         guard let amount = amount else { return }
         guard let address = address, !address.isEmpty else { return _ = handleValidationResult(.invalidAddress) }
         
-        print("updateFeesMax Amount: \(amount.description)")
+//        print("updateFeesMax Amount: \(amount.description)")
         
         sender.estimateFee(address: address, amount: amount, tier: feeLevel, isStake: false) { [weak self] result in
             DispatchQueue.main.async {
@@ -333,7 +341,7 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
                     }
                     let fee = Amount(cryptoAmount: feeBasis.fee, currency: feeCurrency)
                     
-                    print("fee: \(fee.description)")
+                    print("updateFeesMax fee: \(fee.description)")
                     
                     var value = amount
                     if amount.currency == fee.currency && amount.currency.network.name != Currencies.shared.eth?.name {

--- a/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
+++ b/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
@@ -283,18 +283,22 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
             if max.currency.network.name == Currencies.shared.eth?.name {
                 let adjustTokenVal = max.tokenValue * 0.05
                 let adjustAmount = Amount(tokenString: "\(adjustTokenVal)", currency: max.currency)
+                print("max before: \(max.description)")
                 max = max - adjustAmount
+                print("max after: \(max.description)")
             }
             
-            self?.amountView.forceUpdateAmount(amount: max)
+//            self?.amountView.forceUpdateAmount(amount: max)
             
-            self?.updateFeesMax()
+            self?.updateFeesMax(amount: max)
         }
     }
     
     @objc private func updateFees() {
         guard let amount = amount else { return }
         guard let address = address, !address.isEmpty else { return _ = handleValidationResult(.invalidAddress) }
+        
+        print("updateFees Amount: \(amount.description)")
         
         sender.estimateFee(address: address, amount: amount, tier: feeLevel, isStake: false) { [weak self] result in
             DispatchQueue.main.async {
@@ -312,9 +316,11 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
         }
     }
     
-    @objc private func updateFeesMax() {
-        guard let amount = amount else { return }
+    private func updateFeesMax(amount: Amount) {
+//        guard let amount = amount else { return }
         guard let address = address, !address.isEmpty else { return _ = handleValidationResult(.invalidAddress) }
+        
+        print("updateFeesMax Amount: \(amount.description)")
         
         sender.estimateFee(address: address, amount: amount, tier: feeLevel, isStake: false) { [weak self] result in
             DispatchQueue.main.async {
@@ -329,11 +335,13 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
                     }
                     let fee = Amount(cryptoAmount: feeBasis.fee, currency: feeCurrency)
                     
+                    print("fee: \(fee.description)")
+                    
                     var value = amount
-                    if amount.currency == fee.currency {
+                    if amount.currency == fee.currency && amount.currency.network.name != Currencies.shared.eth?.name {
                         value = amount > fee ? amount - fee : amount
                     }
-                    
+
                     self?.amountView.forceUpdateAmount(amount: value)
                     
                 case .failure(let error):

--- a/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
+++ b/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
@@ -281,7 +281,7 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
             self?.isSendingMax = true
             
             if max.currency.network.name == Currencies.shared.eth?.name {
-                let adjustTokenVal = max.tokenValue * 0.15
+                let adjustTokenVal = max.tokenValue * 0.15 // Reduce amount for ETH estimate fee API call
                 let adjustAmount = Amount(tokenString: "\(adjustTokenVal)", currency: max.currency)
                 max = max - adjustAmount
                 self?.amountView.forceUpdateAmount(amount: max)


### PR DESCRIPTION
Changes to brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift:
Fixed updateFeesMax so that the estimateFeeBasis is the same for both the estimate for the confirmation and for the actual send.

Changes to WalletKit:

src/crypto/handlers/btc/BRCryptoWalletSweeperBTC.c:
- Added handler for BSV in that doubles the transaction size estimation to prevent an underestimate of the transaction size.
- Added separate handlers for BTC, BSV, BCH that enforces a minimum fee (BTC 10 sat/byte, BSV 2 sat/byte, BCH 2 sat/byte).

src/crypto/handlers/btc/BRCryptoWalletManagerBTC.c:
- Updated cryptoWalletManagerEstimateLimitBTC to enforce a 10 sat/byte minimum.

src/crypto/handlers/eth/BRCryptoWalletManagerETH.c:
- Updated cryptoWalletManagerEstimateLimitETH to reduce the estimated max by 15% so that amount + fee < balance to prevent failure of the API call for ETH estimateFee.