### PR TITLE
RW-532 Revised sendMax logic for ETH

### DIFF
--- a/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
+++ b/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
@@ -282,9 +282,9 @@ class SendViewController: UIViewController, Subscriber, ModalPresentable {
             
             if max.currency.network.name == Currencies.shared.eth?.name {
                 if max.currency.isEthereum { // Only adjust maximum for ETH
-                    let adjustTokenVal = max.tokenValue * 0.15 // Reduce amount for ETH estimate fee API call
-                    let adjustAmount = Amount(tokenString: "\(adjustTokenVal)", currency: max.currency)
-                    max = max - adjustAmount
+                    let tokenValue = Decimal(string: max.tokenUnformattedString(in: max.currency.defaultUnit))
+                    let adjustTokenValue = (tokenValue ?? Decimal.zero) * 0.85 // Reduce amount for ETH estimate fee API call
+                    max = Amount(tokenString: String(describing: adjustTokenValue), currency: max.currency)
                 }
                 self?.amountView.forceUpdateAmount(amount: max)
             } else {


### PR DESCRIPTION
Please check that the multiplication of 0.85 and the token value is being done correctly. This pull request avoids the operation max - 0.15*tokenAmount to eliminate Amount subtraction as a cause for the very large ETH amount for send all.