### PR TITLE
CXPS-509 Update feeBasis on error path

### DIFF
--- a/brd-ios/breadwallet.xcodeproj/project.pbxproj
+++ b/brd-ios/breadwallet.xcodeproj/project.pbxproj
@@ -5905,7 +5905,7 @@
 			repositoryURL = "https://github.com/rockwalletcode/wallet-kit.git";
 			requirement = {
 				kind = exactVersion;
-				version = 5.0.14;
+				version = 5.0.15;
 			};
 		};
 		7E5CB32B2834E63400EC787E /* XCRemoteSwiftPackageReference "cosmos" */ = {

--- a/brd-ios/breadwallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/brd-ios/breadwallet.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -64,6 +64,15 @@
       }
     },
     {
+      "identity" : "sardine-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/rockwalletcode/sardine-ios.git",
+      "state" : {
+        "revision" : "77f943e9a7c2b0b855ecd6d9b4907315bf2942d8",
+        "version" : "1.0.2"
+      }
+    },
+    {
       "identity" : "snapkit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/SnapKit/SnapKit.git",
@@ -86,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rockwalletcode/wallet-kit.git",
       "state" : {
-        "revision" : "43870d6324c297e4fe89a1753d033b0c2f8e941c",
-        "version" : "5.0.14"
+        "revision" : "c587099ddfad96fb1d306bb89fe4bc3cee7ef45b",
+        "version" : "5.0.15"
       }
     },
     {
@@ -95,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rockwalletcode/wallet-kit-core.git",
       "state" : {
-        "revision" : "ee116ab18ccf9d5297cf0e5c1258c4aca1b43639",
-        "version" : "5.0.14"
+        "revision" : "fc0acd464c7a71fd060101f109311008b0be02ef",
+        "version" : "5.0.15"
       }
     }
   ],

--- a/brd-ios/breadwallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/brd-ios/breadwallet.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -95,8 +95,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rockwalletcode/wallet-kit.git",
       "state" : {
-        "revision" : "43870d6324c297e4fe89a1753d033b0c2f8e941c",
-        "version" : "5.0.14"
+        "revision" : "c587099ddfad96fb1d306bb89fe4bc3cee7ef45b",
+        "version" : "5.0.15"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/rockwalletcode/wallet-kit-core.git",
       "state" : {
-        "revision" : "ee116ab18ccf9d5297cf0e5c1258c4aca1b43639",
-        "version" : "5.0.14"
+        "revision" : "fc0acd464c7a71fd060101f109311008b0be02ef",
+        "version" : "5.0.15"
       }
     }
   ],

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Swap/Main/SwapInteractor.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Swap/Main/SwapInteractor.swift
@@ -213,7 +213,9 @@ class SwapInteractor: NSObject, Interactor, SwapViewActions {
                 self?.presenter?.presentError(actionResponse: .init(error: error))
             } else if self?.dataStore?.quote?.fromFee?.fee != nil {
                 // Not enough ETH for fee
-                self?.presenter?.presentError(actionResponse: .init(error: ExchangeErrors.notEnoughEthForFee(currency: from.currency.code)))
+                let value = self?.dataStore?.from?.tokenValue ?? 0
+                let error = ExchangeErrors.balanceTooLow(balance: value, currency: from.currency.code)
+                self?.presenter?.presentError(actionResponse: .init(error: error))
             }
         }
     }

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Swap/Main/SwapPresenter.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Swap/Main/SwapPresenter.swift
@@ -99,6 +99,12 @@ final class SwapPresenter: NSObject, Presenter, SwapActionResponses {
         } else if ExchangeManager.shared.canSwap(actionResponse.from?.currency) == false {
             presentError(actionResponse: .init(error: ExchangeErrors.pendingSwap))
             hasError = true
+        } else if let feeAmount = fromFee,
+                  let feeWallet = feeAmount.currency.wallet,
+                  feeAmount.currency.isEthereum && feeAmount > feeWallet.balance {
+            let error = ExchangeErrors.balanceTooLow(balance: feeAmount.tokenValue, currency: feeAmount.currency.code)
+            presentError(actionResponse: .init(error: error))
+            hasError = true
         } else {
             let fiatValue = (actionResponse.from?.fiatValue ?? 0).round(to: 2)
             let tokenValue = actionResponse.from?.tokenValue ?? 0


### PR DESCRIPTION
This pull request addresses customer ticket https://bayes.atlassian.net/browse/CXPS-509 regarding the ETH fees not displaying for the insufficient gas fees error message. The fix involved a revision to walletkit error message handling. When an insufficient gas fee error message is received from the backend, walletkit will communicate the feeBasis for the requested amount to the swift layer for send/swap so that the computed fees are displayed. The customer can use the computed fee information to know how much ETH must be added to their wallet to complete the transaction.