### PR TITLE
Updated ETH send max to remove reduction and reduced recursion

### DIFF
--- a/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
+++ b/brd-ios/breadwallet/src/ViewControllers/RootModals/SendViewController.swift
@@ -359,11 +359,9 @@ class SendViewController: BaseSendViewController, Subscriber, ModalPresentable {
                     }
                     
                     if maximum.currency.isEthereum {
-                        let adjustTokenValue = value.tokenValue * 0.95 // Reduce amount for ETH createTxn API call
-                        value = Amount(tokenString: ExchangeFormatter.current.string(for: adjustTokenValue) ?? "0", currency: value.currency)
                         self?.amountView.forceUpdateAmount(amount: value)
                     } else {
-                        if value != amount && depth < 5 { // Call recursively until the amount + fee = maximum up to 5 iterations
+                        if value != amount && depth < 3 { // Call recursively until the amount + fee = maximum up to 3 iterations
                             self?.amountView.forceUpdateAmount(amount: value)
                             self?.updateFeesMax(depth: depth + 1)
                         }


### PR DESCRIPTION
This pull request removes a 0.95 multiplier that was applied to the maximum ETH amount for a send all that was incorporated to account for the ETH fee markup bug. Since the ETH markup bug is now fixed, we do not need this 0.95 multiplier for the ETH send all. Also, the recursive depth of updateFeesMax was reduced to three. Three iterations is sufficient to converge on an amount such that amount + fee = maximum.