### PR TITLE
Fix excess amount of Quote calls 8

### DIFF
--- a/brd-ios/breadwallet/Helpers/Networking/Endpoints/KYCAuthEndpoints.swift
+++ b/brd-ios/breadwallet/Helpers/Networking/Endpoints/KYCAuthEndpoints.swift
@@ -19,7 +19,6 @@ enum KYCAuthEndpoints: String, URLType {
     case longPollBiometricStatus = "kyc/long-poll-biometric-status?quote_id=%@"
     case longPollBiometricStatusLimits = "kyc/long-poll-biometric-status?biometric_type=%@"
     case basic = "kyc/basic"
-    case documents = "kyc/documents"
     case upload = "kyc/upload"
     case submit = "kyc/session/submit"
     case confirmationCodes = "confirmation-codes"

--- a/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Controllers/BaseExchangeTableViewController.swift
+++ b/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Controllers/BaseExchangeTableViewController.swift
@@ -14,6 +14,8 @@ class BaseExchangeTableViewController<C: CoordinatableRoutes,
                                       I: Interactor,
                                       P: Presenter,
                                       DS: BaseDataStore & NSObject>: BaseTableViewController<C, I, P, DS> {
+    typealias Models = AssetModels
+    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
@@ -24,6 +26,8 @@ class BaseExchangeTableViewController<C: CoordinatableRoutes,
         super.viewWillDisappear(animated)
         
         ExchangeManager.shared.reload()
+        
+        getRateAndTimerCell()?.wrappedView.invalidate()
     }
     
     override func setupSubviews() {
@@ -127,6 +131,18 @@ class BaseExchangeTableViewController<C: CoordinatableRoutes,
         default:
             break
         }
+    }
+    
+    func getRateAndTimerCell() -> WrapperTableViewCell<ExchangeRateView>? {
+        guard let section = sections.firstIndex(where: { $0.hashValue == Models.Section.rateAndTimer.hashValue }),
+              let cell = tableView.cellForRow(at: IndexPath(row: 0, section: section)) as? WrapperTableViewCell<ExchangeRateView> else {
+            continueButton.viewModel?.enabled = false
+            verticalButtons.wrappedView.getButton(continueButton)?.setup(with: continueButton.viewModel)
+            
+            return nil
+        }
+        
+        return cell
     }
     
     func limitsInfoTapped() {}

--- a/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Controllers/BaseExchangeTableViewController.swift
+++ b/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Controllers/BaseExchangeTableViewController.swift
@@ -14,29 +14,16 @@ class BaseExchangeTableViewController<C: CoordinatableRoutes,
                                       I: Interactor,
                                       P: Presenter,
                                       DS: BaseDataStore & NSObject>: BaseTableViewController<C, I, P, DS> {
-    var didTriggerExchangeRate: (() -> Void)?
-    
-    private var didDisplayData = false
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         
         ExchangeManager.shared.reload()
-        
-        guard didDisplayData else { return }
-        didTriggerExchangeRate?()
     }
     
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
         
         ExchangeManager.shared.reload()
-    }
-    
-    override func displayData(responseDisplay: FetchModels.Get.ResponseDisplay) {
-        super.displayData(responseDisplay: responseDisplay)
-        
-        didDisplayData = true
     }
     
     override func setupSubviews() {

--- a/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Cycles/AchPayment/AchPaymentModels.swift
+++ b/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Cycles/AchPayment/AchPaymentModels.swift
@@ -20,10 +20,6 @@ enum AchPaymentModels {
         struct ActionResponse {
             var item: PaymentCard?
         }
-        
-        struct ResponseDisplay {
-            var viewModel: CardSelectionViewModel?
-        }
     }
     
     struct PaymentCards {

--- a/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Cycles/AchPayment/AchPaymentVIP.swift
+++ b/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Cycles/AchPayment/AchPaymentVIP.swift
@@ -25,11 +25,10 @@ protocol AchActionResponses: AnyObject {
     func presentPlaidToken(actionResponse: AchPaymentModels.Link.ActionResponse)
 }
 
-protocol AchResponseDisplays: AnyObject {
+protocol AchResponseDisplays: AnyObject, AssetResponseDisplays {
     var plaidHandler: PlaidLinkKitHandler? { get set }
     
     func displayPaymentCards(responseDisplay: AchPaymentModels.PaymentCards.ResponseDisplay)
-    func displayAch(responseDisplay: AchPaymentModels.Get.ResponseDisplay)
     func displayPlaidToken(responseDisplay: AchPaymentModels.Link.ResponseDisplay)
 }
 
@@ -145,7 +144,8 @@ extension Interactor where Self: AchViewActions,
 }
 
 extension Presenter where Self: AchActionResponses,
-                          Self.ResponseDisplays: AchResponseDisplays {
+                          Self.ResponseDisplays: AchResponseDisplays,
+                          Self.ResponseDisplays: AssetResponseDisplays {
     func presentPaymentCards(actionResponse: AchPaymentModels.PaymentCards.ActionResponse) {
         viewController?.displayPaymentCards(responseDisplay: .init(allPaymentCards: actionResponse.allPaymentCards))
     }
@@ -172,7 +172,7 @@ extension Presenter where Self: AchActionResponses,
                                     userInteractionEnabled: true)
         }
         
-        viewController?.displayAch(responseDisplay: .init(viewModel: achPaymentModel))
+        viewController?.displayAmount(responseDisplay: .init(cardModel: achPaymentModel))
     }
     
     func presentPlaidToken(actionResponse: AchPaymentModels.Link.ActionResponse) {
@@ -197,6 +197,4 @@ extension Controller where Self: AchResponseDisplays {
         plaidHandler = responseDisplay.plaidHandler
         plaidHandler?.open(presentUsing: .viewController(self))
     }
-    
-    func displayAch(responseDisplay: AchPaymentModels.Get.ResponseDisplay) {}
 }

--- a/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Cycles/Asset/AssetModels.swift
+++ b/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Cycles/Asset/AssetModels.swift
@@ -42,6 +42,8 @@ enum AssetModels {
             
             var currency: String?
             var card: PaymentCard?
+            
+            var didFinish: Bool = false
         }
         
         struct ActionResponse {

--- a/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Cycles/Asset/AssetVIP.swift
+++ b/brd-ios/breadwallet/src/Redesign/Core/CLEANerSwift/Cycles/Asset/AssetVIP.swift
@@ -19,13 +19,13 @@ protocol AssetViewActions {
     func prepareCurrencies(viewAction: AssetModels.Item)
 }
 
-protocol AssetActionResponses {
+protocol AssetActionResponses: AnyObject {
     func presentExchangeRate(actionResponse: AssetModels.ExchangeRate.ActionResponse, completion: (() -> Void)?)
     func handleError(actionResponse: AssetModels.Asset.ActionResponse) -> Bool
     func presentAmount(actionResponse: AssetModels.Asset.ActionResponse)
 }
 
-protocol AssetResponseDisplays {
+protocol AssetResponseDisplays: AnyObject {
     var tableView: ContentSizedTableView { get set }
     var continueButton: FEButton { get set }
     

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Buy/Main/BuyViewController.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Buy/Main/BuyViewController.swift
@@ -31,13 +31,13 @@ class BuyViewController: BaseExchangeTableViewController<ExchangeCoordinator,
     
     // MARK: - Overrides
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func prepareData() {
+        super.prepareData()
         
         GoogleAnalytics.logEvent(GoogleAnalytics.Buy(type: dataStore?.paymentMethod?.rawValue ?? ""))
         
         Store.subscribe(self, name: .reloadBuy) { [weak self] _ in
-            self?.prepareData()
+            self?.interactor?.getData(viewAction: .init())
         }
     }
     
@@ -45,14 +45,6 @@ class BuyViewController: BaseExchangeTableViewController<ExchangeCoordinator,
         super.viewWillDisappear(animated)
         
         getRateAndTimerCell()?.wrappedView.invalidate()
-    }
-    
-    override func setupSubviews() {
-        super.setupSubviews()
-        
-        didTriggerExchangeRate = { [weak self] in
-            self?.interactor?.getData(viewAction: .init())
-        }
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -107,7 +99,7 @@ class BuyViewController: BaseExchangeTableViewController<ExchangeCoordinator,
             }
             
             view.didFinish = { [weak self] _ in
-                self?.interactor?.setAmount(viewAction: .init())
+                self?.interactor?.setAmount(viewAction: .init(didFinish: true))
             }
             
             view.didTapSelectAsset = { [weak self] in
@@ -152,6 +144,8 @@ class BuyViewController: BaseExchangeTableViewController<ExchangeCoordinator,
         if paymentTypes.count >= segment {
             let paymentType = paymentTypes[segment]
             interactor?.selectPaymentMethod(viewAction: .init(method: paymentType))
+            
+            GoogleAnalytics.logEvent(GoogleAnalytics.Buy(type: paymentType.rawValue))
         }
     }
     
@@ -239,7 +233,7 @@ class BuyViewController: BaseExchangeTableViewController<ExchangeCoordinator,
             }
             
             self?.coordinator?.dismissFlow()
-            self?.interactor?.setAmount(viewAction: .init(currency: model.subtitle))
+            self?.interactor?.setAmount(viewAction: .init(currency: model.subtitle, didFinish: true))
         }
     }
     
@@ -259,10 +253,6 @@ class BuyViewController: BaseExchangeTableViewController<ExchangeCoordinator,
             
             return
         }
-        
-        sectionRows[fromSection] = [responseDisplay.swapCurrencyViewModel as Any]
-        sectionRows[toSection] = [responseDisplay.cardModel as Any]
-        sectionRows[limitActionsSection] = [responseDisplay.limitActions as Any]
         
         fromCell.wrappedView.setup(with: responseDisplay.swapCurrencyViewModel)
         toCell.wrappedView.setup(with: responseDisplay.cardModel)
@@ -302,18 +292,6 @@ class BuyViewController: BaseExchangeTableViewController<ExchangeCoordinator,
     
     func displayInstantAchPopup(responseDisplay: BuyModels.InstantAchPopup.ResponseDisplay) {
         coordinator?.showPopup(with: responseDisplay.model)
-    }
-    
-    func displayAch(responseDisplay: AchPaymentModels.Get.ResponseDisplay) {
-        guard let section = sections.firstIndex(where: { $0.hashValue == Models.Section.paymentMethod.hashValue }),
-              let cell = tableView.cellForRow(at: IndexPath(row: 0, section: section)) as? WrapperTableViewCell<CardSelectionView> else { return }
-        
-        cell.wrappedView.setup(with: responseDisplay.viewModel)
-        
-        tableView.invalidateTableViewIntrinsicContentSize()
-        
-        continueButton.viewModel?.enabled = dataStore?.isFormValid ?? false
-        verticalButtons.wrappedView.getButton(continueButton)?.setup(with: continueButton.viewModel)
     }
     
     // MARK: - Additional Helpers

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Buy/Main/BuyViewController.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Buy/Main/BuyViewController.swift
@@ -41,12 +41,6 @@ class BuyViewController: BaseExchangeTableViewController<ExchangeCoordinator,
         }
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        getRateAndTimerCell()?.wrappedView.invalidate()
-    }
-    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell
         switch dataSource?.sectionIdentifier(for: indexPath.section) as? Models.Section {
@@ -176,19 +170,6 @@ class BuyViewController: BaseExchangeTableViewController<ExchangeCoordinator,
             view.configure(with: .init(buttons: [Presets.Button.noBorders],
                                                    axis: .vertical))
             view.setup(with: model)
-        }
-        
-        return cell
-    }
-    
-    func getRateAndTimerCell() -> WrapperTableViewCell<ExchangeRateView>? {
-        guard let section = sections.firstIndex(where: { $0.hashValue == Models.Section.rateAndTimer.hashValue }),
-              let cell = tableView.cellForRow(at: IndexPath(row: 0, section: section)) as? WrapperTableViewCell<ExchangeRateView> else {
-            continueButton.viewModel?.enabled = false
-            continueButton.setup(with: continueButton.viewModel)
-            verticalButtons.wrappedView.getButton(continueButton)?.setup(with: continueButton.viewModel)
-            
-            return nil
         }
         
         return cell

--- a/brd-ios/breadwallet/src/Redesign/Scenes/REUSABLE/Protocols/AssetSelectionDisplayable.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/REUSABLE/Protocols/AssetSelectionDisplayable.swift
@@ -47,14 +47,11 @@ extension AssetSelectionDisplayable where Self: BaseCoordinator {
         }
         
         let unsupportedAssets = supportedAssets.filter { item in !(data?.contains(where: { $0.subtitle?.lowercased() == item.code }) ?? false) }
-        
         let disabledData: [AssetViewModel]? = unsupportedAssets.compactMap {
-            let isDisabledAsset = isDisabledAsset(code: $0.code, supportedCurrencies: supportedCurrencies) ?? false
-            
             return AssetViewModel(icon: $0.imageSquareBackground,
                                   title: $0.name,
                                   subtitle: $0.code.uppercased(),
-                                  isDisabled: isDisabledAsset)
+                                  isDisabled: true)
         }
         
         data?.append(contentsOf: disabledData ?? [])

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellInteractor.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellInteractor.swift
@@ -85,6 +85,10 @@ class SellInteractor: NSObject, Interactor, SellViewActions {
     func achSuccessMessage(viewAction: AchPaymentModels.Get.ViewAction) {
         let isRelinking = dataStore?.selected?.status == .requiredLogin
         presenter?.presentAchSuccess(actionResponse: .init(isRelinking: isRelinking))
+        
+        getExchangeRate(viewAction: .init(getFees: false), completion: { [weak self] in
+            self?.setPresentAmountData(handleErrors: false)
+        })
     }
     
     func setAmount(viewAction: AssetModels.Asset.ViewAction) {

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellInteractor.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellInteractor.swift
@@ -98,6 +98,7 @@ class SellInteractor: NSObject, Interactor, SellViewActions {
             
             prepareFees(viewAction: .init(), completion: {})
             
+            guard viewAction.didFinish else { return }
             getExchangeRate(viewAction: .init(getFees: false), completion: { [weak self] in
                 self?.setPresentAmountData(handleErrors: false)
             })
@@ -105,6 +106,11 @@ class SellInteractor: NSObject, Interactor, SellViewActions {
             return
         } else if let value = viewAction.card {
             dataStore?.selected = value
+            
+            guard viewAction.didFinish else { return }
+            getExchangeRate(viewAction: .init(getFees: false), completion: { [weak self] in
+                self?.setPresentAmountData(handleErrors: false)
+            })
             
             return
         }

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellPresenter.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellPresenter.swift
@@ -26,7 +26,6 @@ final class SellPresenter: NSObject, Presenter, SellActionResponses {
             .rateAndTimer,
             .swapCard,
             .paymentMethod,
-            .accountLimits,
             .accountLimits
         ]
         

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellViewController.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellViewController.swift
@@ -30,12 +30,6 @@ class SellViewController: BaseExchangeTableViewController<ExchangeCoordinator,
         GoogleAnalytics.logEvent(GoogleAnalytics.Sell())
     }
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        getRateAndTimerCell()?.wrappedView.invalidate()
-    }
-    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell
         switch dataSource?.sectionIdentifier(for: indexPath.section) as? Models.Section {
@@ -111,19 +105,6 @@ class SellViewController: BaseExchangeTableViewController<ExchangeCoordinator,
             view.didTapLink = { [weak self] in
                 self?.interactor?.showLimitsInfo(viewAction: .init())
             }
-        }
-        
-        return cell
-    }
-    
-    func getRateAndTimerCell() -> WrapperTableViewCell<ExchangeRateView>? {
-        guard let section = sections.firstIndex(where: { $0.hashValue == Models.Section.rateAndTimer.hashValue }),
-              let cell = tableView.cellForRow(at: IndexPath(row: 0, section: section)) as? WrapperTableViewCell<ExchangeRateView> else {
-            continueButton.viewModel?.enabled = false
-            continueButton.setup(with: continueButton.viewModel)
-            verticalButtons.wrappedView.getButton(continueButton)?.setup(with: continueButton.viewModel)
-            
-            return nil
         }
         
         return cell

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellViewController.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellViewController.swift
@@ -24,8 +24,8 @@ class SellViewController: BaseExchangeTableViewController<ExchangeCoordinator,
     
     // MARK: - Overrides
     
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    override func prepareData() {
+        super.prepareData()
         
         GoogleAnalytics.logEvent(GoogleAnalytics.Sell())
     }
@@ -34,14 +34,6 @@ class SellViewController: BaseExchangeTableViewController<ExchangeCoordinator,
         super.viewWillDisappear(animated)
         
         getRateAndTimerCell()?.wrappedView.invalidate()
-    }
-    
-    override func setupSubviews() {
-        super.setupSubviews()
-        
-        didTriggerExchangeRate = { [weak self] in
-            self?.interactor?.getExchangeRate(viewAction: .init(getFees: false), completion: {})
-        }
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -90,7 +82,7 @@ class SellViewController: BaseExchangeTableViewController<ExchangeCoordinator,
             }
             
             view.didFinish = { [weak self] _ in
-                self?.interactor?.setAmount(viewAction: .init())
+                self?.interactor?.setAmount(viewAction: .init(didFinish: true))
             }
             
             view.didTapFromAssetsSelection = { [weak self] in
@@ -172,7 +164,7 @@ class SellViewController: BaseExchangeTableViewController<ExchangeCoordinator,
             }
             
             self?.coordinator?.dismissFlow()
-            self?.interactor?.setAmount(viewAction: .init(currency: model.subtitle))
+            self?.interactor?.setAmount(viewAction: .init(currency: model.subtitle, didFinish: true))
         }
     }
     

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellViewController.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Sell/Main/SellViewController.swift
@@ -235,16 +235,4 @@ class SellViewController: BaseExchangeTableViewController<ExchangeCoordinator,
     func displayInstantAchPopup(responseDisplay: SellModels.InstantAchPopup.ResponseDisplay) {
         coordinator?.showPopup(with: responseDisplay.model)
     }
-    
-    func displayAch(responseDisplay: AchPaymentModels.Get.ResponseDisplay) {
-        guard let section = sections.firstIndex(where: { $0.hashValue == Models.Section.paymentMethod.hashValue }),
-              let cell = tableView.cellForRow(at: IndexPath(row: 0, section: section)) as? WrapperTableViewCell<CardSelectionView> else { return }
-        
-        cell.wrappedView.setup(with: responseDisplay.viewModel)
-        
-        tableView.invalidateTableViewIntrinsicContentSize()
-        
-        continueButton.viewModel?.enabled = dataStore?.isFormValid ?? false
-        verticalButtons.wrappedView.getButton(continueButton)?.setup(with: continueButton.viewModel)
-    }
 }

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Swap/Main/SwapInteractor.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Swap/Main/SwapInteractor.swift
@@ -34,14 +34,15 @@ class SwapInteractor: NSObject, Interactor, SwapViewActions {
         let fromCurrency: Currency? = dataStore?.fromAmount != nil ? dataStore?.fromAmount?.currency : dataStore?.currencies.first
         
         guard let fromCurrency,
-              let toCurrency = dataStore?.currencies.first(where: { $0.code != fromCurrency.code })
-        else {
+              let toCurrency = dataStore?.currencies.first(where: { $0.code != fromCurrency.code }) else {
             presenter?.presentError(actionResponse: .init(error: ExchangeErrors.selectAssets))
             return
         }
+        
         if dataStore?.fromAmount == nil {
             dataStore?.fromAmount = .zero(fromCurrency)
         }
+        
         dataStore?.toAmount = .zero(toCurrency)
         
         presenter?.presentData(actionResponse: .init(item: Models.Item(fromAmount: dataStore?.fromAmount,

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Swap/Main/SwapViewController.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Swap/Main/SwapViewController.swift
@@ -29,14 +29,6 @@ class SwapViewController: BaseExchangeTableViewController<ExchangeCoordinator,
         getRateAndTimerCell()?.wrappedView.invalidate()
     }
     
-    override func setupSubviews() {
-        super.setupSubviews()
-        
-        didTriggerExchangeRate = { [weak self] in
-            self?.interactor?.getExchangeRate(viewAction: .init(getFees: true), completion: {})
-        }
-    }
-    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell
         switch dataSource?.sectionIdentifier(for: indexPath.section) as? Models.Section {

--- a/brd-ios/breadwallet/src/Redesign/Scenes/Swap/Main/SwapViewController.swift
+++ b/brd-ios/breadwallet/src/Redesign/Scenes/Swap/Main/SwapViewController.swift
@@ -23,12 +23,6 @@ class SwapViewController: BaseExchangeTableViewController<ExchangeCoordinator,
     
     // MARK: - Overrides
     
-    override func viewWillDisappear(_ animated: Bool) {
-        super.viewWillDisappear(animated)
-        
-        getRateAndTimerCell()?.wrappedView.invalidate()
-    }
-    
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: UITableViewCell
         switch dataSource?.sectionIdentifier(for: indexPath.section) as? Models.Section {
@@ -104,15 +98,6 @@ class SwapViewController: BaseExchangeTableViewController<ExchangeCoordinator,
             }
             
             view.setupCustomMargins(top: .zero, leading: .zero, bottom: .medium, trailing: .zero)
-        }
-        
-        return cell
-    }
-    
-    func getRateAndTimerCell() -> WrapperTableViewCell<ExchangeRateView>? {
-        guard let section = sections.firstIndex(where: { $0.hashValue == Models.Section.rateAndTimer.hashValue }),
-              let cell = tableView.cellForRow(at: IndexPath(row: 0, section: section)) as? WrapperTableViewCell<ExchangeRateView> else {
-            return nil
         }
         
         return cell


### PR DESCRIPTION
- Test before merging. Also test the same flows from Assets screen.
- Might also need additional tweaking for Sprint 9.
- Fixes excess amount of Quote calls. 
- Fixes the non-existent currency pair error. To replicate, choose non-ach-supported asset like LTC then switch to "BUY WITH ACH" from the segmented control. It should now choose the first supported asset in your list.
- Fixes analytics event Buy.
- Fixes Swap screen already selected currency not being greyed out. 